### PR TITLE
chore(devfile) use ubi-latest tag for UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
       env:
         - name: GOPATH
           value: /projects:/home/user/go


### PR DESCRIPTION
chore(devfile) use ubi-latest tag for UDI

Related issue: https://github.com/eclipse/che/issues/21979

![Screenshot from 2023-03-21 15-02-40](https://user-images.githubusercontent.com/1271546/226614237-46b16843-cdde-4d0e-9e73-8dd5903d1d0e.png)
