### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -11,8 +11,9 @@ components:
         - name: GOCACHE
           value: /tmp/.cache
       endpoints:
-        - name: 8080-tcp
+        - name: 8080-https
           targetPort: 8080
+          protocol: https
       memoryLimit: 2Gi
       mountSources: true
 


### PR DESCRIPTION
chore: use https protocol in endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-11_29_34](https://github.com/che-samples/golang-example/assets/1271546/09cfe76b-7aa9-4cad-80ce-e8249dea72d2)

Related issue: https://issues.redhat.com/browse/CRW-5377