### PR TITLE
devfile:set schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: golang-example
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_34_56](https://github.com/che-samples/golang-example/assets/1271546/d0c5d302-04e1-4b1d-ab46-0da8bff93ba4)


Related issue: https://github.com/eclipse/che/issues/21985

